### PR TITLE
Introduce CyclicDependencyTestRunner

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,3 @@
-#Wed Dec 02 20:32:04 PST 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16

--- a/kawala-testing/src/main/java/com/kaching/platform/testing/CyclicDependencyTestRunner.java
+++ b/kawala-testing/src/main/java/com/kaching/platform/testing/CyclicDependencyTestRunner.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2010 Wealthfront Inc. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.kaching.platform.testing;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jdepend.framework.JDepend;
+import jdepend.framework.JavaPackage;
+import jdepend.framework.PackageFilter;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.kaching.platform.testing.CyclicDependencyTestRunner.PackagesBuilder.Result;
+
+/**
+ * @see <a href="http://clarkware.com/software/JDepend.html#junit">JDepend and JUnit</a>
+ */
+public class CyclicDependencyTestRunner extends AbstractDeclarativeTestRunner<CyclicDependencyTestRunner.Packages> {
+
+  @Target(TYPE)
+  @Retention(RUNTIME)
+  public @interface Packages {
+
+    public int minClasses() default 10;
+
+    public String[] forPackages();
+
+    public String[] binDirectories() default "target/test-classes";
+
+    public String binDirectoryProperty() default "kawala.bin_directories";
+
+  }
+
+  public CyclicDependencyTestRunner(Class<?> testClass) {
+    super(testClass, Packages.class);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected void runTest(final Packages dependencies) throws IOException {
+    Result results = getTestResults(dependencies);
+    /* This assertion is meant as a sanity check. It makes sure that when
+     * run, JDepend can correctly find the project's classes. Otherwise, the
+     * test could pass simply because the path is incorrect or the build
+     * assembles classes in a different directory.
+     */
+    assertTrue(
+        format(
+            "project does not contain more than %s classes, only %s found",
+            dependencies.minClasses(), results.numClasses),
+        dependencies.minClasses() < results.numClasses);
+
+    assertFalse(results.hasCycle());
+  }
+
+  Result getTestResults(final Packages dependencies) throws IOException {
+    JDepend jDepend = new JDepend();
+    String binDirectoryProperty = getProperty(dependencies.binDirectoryProperty());
+    String[] binDirectories = binDirectoryProperty != null ?
+        binDirectoryProperty.split(":") :
+        dependencies.binDirectories();
+    for (String binDirectory : binDirectories) {
+      if (new File(binDirectory).isDirectory()) {
+        jDepend.addDirectory(binDirectory);
+      }
+    }
+    jDepend.analyzeInnerClasses(true);
+    PackageFilter checkedPackagesFilter = new PackageFilter() {
+      @Override
+      public boolean accept(String scannedPackageName) {
+        for (String expectedPackageName : dependencies.forPackages()) {
+          if (scannedPackageName.startsWith(expectedPackageName)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+    jDepend.setFilter(checkedPackagesFilter);
+    jDepend.analyze();
+
+    Result result = new Result(jDepend.countClasses());
+    if (jDepend.containsCycles()) {
+      for (Object o : jDepend.getPackages()) {
+        JavaPackage pkg = (JavaPackage) o;
+        List<JavaPackage> cycles = Lists.newArrayList();
+        pkg.collectAllCycles(cycles);
+        result.addCycles(cycles);
+      }
+    }
+    return result;
+  }
+
+  static class PackagesBuilder {
+
+    private Set<String> forPackages;
+
+    public PackagesBuilder forPackages(String... packageExpressions) {
+      if (forPackages != null) {
+        throw new IllegalStateException();
+      }
+      forPackages = newHashSet();
+      for (String packageExpression : packageExpressions) {
+        forPackages.add(packageExpression);
+      }
+      return this;
+    }
+
+    PackagesBuilder check(String packageExpression) {
+      if (forPackages == null) {
+        throw new IllegalStateException();
+      }
+      return this;
+    }
+
+    static class Result {
+      final int numClasses;
+      final Map<JavaPackage, Set<JavaPackage>> sccs = Maps.newHashMap();
+      Result(int numClasses) {
+        this.numClasses = numClasses;
+      }
+
+      boolean hasCycle() {
+        return !sccs.isEmpty();
+      }
+
+      void addCycles(List<JavaPackage> cycles) {
+        Set<JavaPackage> scc = Sets.newHashSet(cycles);
+        for (JavaPackage pkg : cycles) {
+          sccs.put(pkg, scc);
+        }
+      }
+
+      Set<Set<JavaPackage>> getUniqueCycles() {
+        return Sets.newHashSet(sccs.values());
+      }
+
+      @Override
+      public String toString() {
+        StringBuilder sb = new StringBuilder("Strongly connected components: {\n");
+        for (Set<JavaPackage> scc : getUniqueCycles()) {
+          boolean first = true;
+          sb.append("[");
+          for (JavaPackage jp : scc) {
+            if (first) {
+              first = false;
+            } else {
+              sb.append(",\n ");
+            }
+            sb.append(jp.getName());
+          }
+          sb.append("]\n");
+        }
+        return sb.append("}").toString();
+      }
+    }
+  }
+
+}

--- a/kawala-testing/src/main/java/com/kaching/platform/testing/CyclicDependencyTestRunner.java
+++ b/kawala-testing/src/main/java/com/kaching/platform/testing/CyclicDependencyTestRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010 Wealthfront Inc. Licensed under the Apache License,
+ * Copyright 2015 Wealthfront Inc. Licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/CyclicDependencyTestRunnerTest.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/CyclicDependencyTestRunnerTest.java
@@ -1,0 +1,76 @@
+package com.kaching.platform.testing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.kaching.platform.testing.CyclicDependencyTestRunner.Packages;
+import com.kaching.platform.testing.CyclicDependencyTestRunner.PackagesBuilder.Result;
+
+public class CyclicDependencyTestRunnerTest {
+
+  @Packages(
+      binDirectories = "target/test-classes",
+      forPackages = "com.kaching.platform.testing.testexamples.a")
+  private static class SinglePackage {}
+
+  @Test
+  public void testSinglePackage_NoCycles() throws IOException {
+    CyclicDependencyTestRunner runner = new CyclicDependencyTestRunner(SinglePackage.class);
+    Result result = runner.getTestResults(SinglePackage.class.getAnnotation(Packages.class));
+    assertTrue(result.numClasses > 0);
+    assertTrue(result.getUniqueCycles().isEmpty());
+  }
+
+  @Packages(
+      binDirectories = "target/test-classes",
+      forPackages = {"com.kaching.platform.testing.testexamples.a",
+                     "com.kaching.platform.testing.testexamples.b"})
+  private static class TwoPackages {}
+
+  @Test
+  public void testTwoPackages_NoCycles() throws IOException {
+    CyclicDependencyTestRunner runner = new CyclicDependencyTestRunner(TwoPackages.class);
+    Result result = runner.getTestResults(TwoPackages.class.getAnnotation(Packages.class));
+    assertTrue(result.numClasses > 0);
+    assertTrue(result.getUniqueCycles().isEmpty());
+  }
+
+  @Packages(
+      binDirectories = "target/test-classes",
+      forPackages = {"com.kaching.platform.testing.testexamples.a",
+                     "com.kaching.platform.testing.testexamples.b",
+                     "com.kaching.platform.testing.testexamples.c"})
+  private static class ThreePackages {}
+
+  @Test
+  public void testThreePackages_Cycles() throws IOException {
+    CyclicDependencyTestRunner runner = new CyclicDependencyTestRunner(ThreePackages.class);
+    Result result = runner.getTestResults(ThreePackages.class.getAnnotation(Packages.class));
+    assertTrue(result.numClasses > 0);
+    assertEquals(1, result.getUniqueCycles().size());
+  }
+
+  @Packages(
+      binDirectories = "target/test-classes",
+      minClasses = 1,
+      forPackages = "com.kaching.platform.testing.testexamples")
+  private static class BasePackage {}
+
+  @Test
+  public void testBasePackage_Cycles() throws IOException {
+    CyclicDependencyTestRunner runner = new CyclicDependencyTestRunner(BasePackage.class);
+    Result result = runner.getTestResults(BasePackage.class.getAnnotation(Packages.class));
+    assertTrue(result.numClasses > 0);
+    assertEquals(1, result.getUniqueCycles().size());
+    assertEquals("Strongly connected components: {\n" +
+        "[com.kaching.platform.testing.testexamples.a,\n"
+        + " com.kaching.platform.testing.testexamples.b,\n"
+        + " com.kaching.platform.testing.testexamples.c]\n"
+        + "}", result.toString());
+  }
+
+}

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/CyclicDependencyTestRunnerTest.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/CyclicDependencyTestRunnerTest.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2015 Wealthfront Inc. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package com.kaching.platform.testing;
 
 import static org.junit.Assert.assertEquals;

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/a/A.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/a/A.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2015 Wealthfront Inc. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package com.kaching.platform.testing.testexamples.a;
 
 import com.kaching.platform.testing.testexamples.c.C;

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/a/A.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/a/A.java
@@ -1,0 +1,7 @@
+package com.kaching.platform.testing.testexamples.a;
+
+import com.kaching.platform.testing.testexamples.c.C;
+
+public class A {
+  C c;
+}

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/b/B.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/b/B.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2015 Wealthfront Inc. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package com.kaching.platform.testing.testexamples.b;
 
 import com.kaching.platform.testing.testexamples.a.A;

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/b/B.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/b/B.java
@@ -1,0 +1,7 @@
+package com.kaching.platform.testing.testexamples.b;
+
+import com.kaching.platform.testing.testexamples.a.A;
+
+public class B {
+  A a;
+}

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/c/C.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/c/C.java
@@ -1,0 +1,7 @@
+package com.kaching.platform.testing.testexamples.c;
+
+import com.kaching.platform.testing.testexamples.b.B;
+
+public class C {
+  B b;
+}

--- a/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/c/C.java
+++ b/kawala-testing/src/test/java/com/kaching/platform/testing/testexamples/c/C.java
@@ -1,3 +1,13 @@
+/**
+ * Copyright 2015 Wealthfront Inc. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package com.kaching.platform.testing.testexamples.c;
 
 import com.kaching.platform.testing.testexamples.b.B;


### PR DESCRIPTION
Uses jDepend to find cycles in a given package.Use of the existing DependencyTestRunner to require clear dependencies between packages has revealed that it is not sufficient to prevent circular dependencies from creeping in, which leads to serious problems when it's desired to break up a monolith into components.

This version does not support exceptions. You may consider that a significant gap, or you may consider it a feature.